### PR TITLE
Update scraper method to include positions and more useful stats

### DIFF
--- a/src/data/make_dataset.py
+++ b/src/data/make_dataset.py
@@ -30,13 +30,13 @@ def make_dataset():
         base_url = 'https://www.baseball-reference.com/leagues/' + args.league + '/'
 
         # batting
-        stats_to_keep = ['G', 'R', 'HR', 'RBI', 'SB', 'batting_avg']
+        stats_to_keep = ['G', 'R', 'HR', 'RBI', 'SB', 'batting_avg', 'pos_summary']
         # season: YYYY
         url = base_url + args.season + '-standard-batting.shtml#players_standard_batting::none'
         scraper_.get_data(url, stats_to_keep)
 
         # pitching
-        stats_to_keep = ['W', 'SV', 'SO', 'ERA', 'WHIP', 'IP']
+        stats_to_keep = ['W', 'SV', 'SO', 'earned_run_avg', 'whip', 'IP', 'GS', 'GF']
         url = base_url + args.season + '-standard-pitching.shtml#players_standard_pitching::none'
         scraper_.get_data(url, stats_to_keep)
 

--- a/src/data/scraper.py
+++ b/src/data/scraper.py
@@ -1,5 +1,6 @@
 import configparser
 from pathlib import Path
+import re
 
 from ohmysportsfeedspy import MySportsFeeds
 import urllib3
@@ -92,6 +93,10 @@ class Scraper_BS(object):
             player = ''
             for child in rows[i].children:
                 try:
+                    #if child.attrs['data-stat'] in 'pos_summary':
+                    #    stat = child.attrs['data-stat']
+                    #    value = child.contents[0]
+                    #    stats[stat] = value
                     if child.attrs['data-stat'] in stats_to_keep:
                         stat = child.attrs['data-stat']
                         if len(child.contents) > 0:
@@ -107,13 +112,15 @@ class Scraper_BS(object):
             for stat in stats_to_keep:
                 if stat not in list(stats.keys()):
                     stats[stat] = None
-                if stats[stat] is not None:
+                if stats[stat] is not None and stat not in 'pos_summary':
                     try:
                         stats[stat] = float(stats[stat])
                     except ValueError:
                         not_real = True
             if not_real:
                 break
+            #if 'pos_summary' in list(stats.keys()):
+            #    stats_to_keep.append('pos_summary')
             players[player] = [stats[stat] for stat in stats_to_keep]
 
         df = pd.DataFrame.from_dict(players, orient='index', columns=stats_to_keep)


### PR DESCRIPTION
In order to get position information, more stats are required.
For fielders, this requires pulling the 'pos_summary' stat from baseball-reference.
For pitchers, the number of games started and games finished is required for SP and RP